### PR TITLE
Specified encoding when opening to fix undefined characters

### DIFF
--- a/helpers/pymupdf_rag.py
+++ b/helpers/pymupdf_rag.py
@@ -312,7 +312,7 @@ if __name__ == "__main__":
     try:
         filename = sys.argv[1]
     except IndexError:
-        print(f"Usage:\npython {os.path.basename(__file__)} Energia Tre 2013.pdf")
+        print(f"Usage:\npython {os.path.basename(__file__)} input.pdf")
         sys.exit()
 
     t0 = time.perf_counter()  # start a time

--- a/helpers/pymupdf_rag.py
+++ b/helpers/pymupdf_rag.py
@@ -312,7 +312,7 @@ if __name__ == "__main__":
     try:
         filename = sys.argv[1]
     except IndexError:
-        print(f"Usage:\npython {os.path.basename(__file__)} input.pdf")
+        print(f"Usage:\npython {os.path.basename(__file__)} Energia Tre 2013.pdf")
         sys.exit()
 
     t0 = time.perf_counter()  # start a time
@@ -341,8 +341,8 @@ if __name__ == "__main__":
     md_string = to_markdown(doc, pages=pages)
 
     # output to a text file with extension ".md"
-    out = open(doc.name.replace(".pdf", ".md"), "w")
-    out.write(md_string)
+    with open(doc.name.replace(".pdf", ".md"), "w", encoding="utf-8") as out:
+        out.write(md_string)
     out.close()
     t1 = time.perf_counter()  # stop timer
     print(f"Markdown creation time for {doc.name=} {round(t1-t0,2)} sec.")


### PR DESCRIPTION
By specifying encoding="utf-8", you ensure that the file is encoded using UTF-8, which can handle a wider range of characters without raising encoding errors