### PR TITLE
add expected type and some typings

### DIFF
--- a/pymupdf4llm/pymupdf4llm/__init__.py
+++ b/pymupdf4llm/pymupdf4llm/__init__.py
@@ -1,4 +1,4 @@
-from .helpers.pymupdf_rag import to_markdown, IdentifyHeaders
+from .helpers.pymupdf_rag import to_markdown, IdentifyHeaders, ChunksType
 
 __version__ = "0.0.3"
 version = __version__


### PR DESCRIPTION
I am suggesting these changes:
- add/fix some typings
- handle some None values
- add an expected_type parameter : this is breaking change, so maybe you suggest a different way of handling this

Why this last change ?
to get the exact type when we use this library, and avoid adding `#type: ignore` every time, or `if isinstance(str) ...`
Maybe you have a better suggestion to handle this ?

I noticed that I should also add typings to the pymupdf library too.