### PR TITLE
Update pymupdf_rag.py to fix compatibility issue with Python 3.9

### DIFF
--- a/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
+++ b/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
@@ -115,13 +115,13 @@ class IdentifyHeaders:
 
 
 def to_markdown(
-    doc: fitz.Document | str,
+    doc: "fitz.Document | str",
     *,
-    pages: list | range | None = None,
-    hdr_info: IdentifyHeaders | None = None,
+    pages: "list | range | None" = None,
+    hdr_info: "IdentifyHeaders | None" = None,
     write_images: bool = False,
     page_chunks: bool = False,
-) -> str | list[dict]:
+) -> "str | list[dict]":
     """Process the document and return the text of its selected pages."""
 
     if isinstance(doc, str):
@@ -163,9 +163,9 @@ def to_markdown(
         textpage: fitz.TextPage,
         clip: fitz.Rect,
         tabs=None,
-        tab_rects: dict | None = None,
-        img_rects: dict | None = None,
-        links: list | None = None,
+        tab_rects: "dict | None" = None,
+        img_rects: "dict | None" = None,
+        links: "list | None" = None,
         hdr_info=None,
     ) -> string:
         """Output the text found inside the given clip.


### PR DESCRIPTION
The pdf4llm library currently uses the | operator for type hinting in its code. However, this operator is only supported in Python 3.10 and above. When running the library on Python 3.9, the following error is encountered:

TypeError: unsupported operand type(s) for |: 'type' and 'type'
This issue prevents users from utilizing the pdf4llm library with Python 3.9, limiting its compatibility and usability.

To address this problem, the code should be modified to use a compatible syntax that works with Python 3.9. This will allow the library to be used seamlessly across different Python versions, including Python 3.9.

Please consider updating the code to remove the usage of the | operator and replace it with a compatible alternative. This will greatly enhance the library's compatibility and make it accessible to a wider range of users.

Thank you for your attention to this matter.

![image](https://github.com/pymupdf/RAG/assets/89332218/d4a7b581-4c4a-4954-b416-7e4dce517133)
