### PR TITLE
Fixed quad abbreviation

### DIFF
--- a/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
+++ b/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
@@ -193,7 +193,7 @@ def is_significant(box, paths):
         for itm in p["items"]:
             if itm[0] in ("l", "c"):  # line or curve
                 points.extend(itm[1:])  # append all the points
-            elif itm[0] == "q":  # quad
+            elif itm[0] == "qu":  # quad
                 q = itm[1]
                 # follow corners anti-clockwise
                 points.extend([q.ul, q.ll, q.lr, q.ur, q.ul])


### PR DESCRIPTION
The first item of a Quad path should be "qu" not "q". Currently, when trying to process a PDF with Quad objects, the process will fail with:
>AttributeError: 'Quad' object has no attribute 'tl'. Did you mean: 'll'?"

This is because the Quad check `elif itm[0] == "q":` evaluates to false and `itm[0]` gets processed liked a Rect. Changing this condition to `elif itm[0] == "qu":` makes Quads correctly processed. 

From the[PyMuPDF docs](https://pymupdf.readthedocs.io/en/latest/page.html#Page.get_drawings), relevant portion in bold:

> Each item in path["items"] is one of the following:
("l", p1, p2) - a line from p1 to p2 ([Point](https://pymupdf.readthedocs.io/en/latest/point.html#point) objects).
("c", p1, p2, p3, p4) - cubic Bézier curve from p1 to p4 (p2 and p3 are the control points). All objects are of type [Point](https://pymupdf.readthedocs.io/en/latest/point.html#point).
("re", rect, orientation) - a [Rect](https://pymupdf.readthedocs.io/en/latest/rect.html#rect). Multiple rectangles within the same path are now detected (changed in v1.18.17). Integer orientation is 1 resp. -1 indicating whether the enclosed area is rotated left (1 = anti-clockwise), or resp. right [[7]](https://pymupdf.readthedocs.io/en/latest/page.html#f7) (changed in v1.19.2).
**("qu", quad) - a [Quad](https://pymupdf.readthedocs.io/en/latest/quad.html#quad). 3 or 4 consecutive lines are detected to actually represent a [Quad](https://pymupdf.readthedocs.io/en/latest/quad.html#quad) (changed in v1.19.2:). (New in v1.18.17)**