### PR TITLE
Add  Option to Control Code Block Formatting in Markdown Output.

### DIFF
--- a/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
+++ b/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
@@ -226,7 +226,7 @@ def to_markdown(
     page_height=None,
     table_strategy="lines_strict",
     graphics_limit=None,
-    enable_code_blocks=False,
+    enable_code_blocks=True,
 ) -> str:
     """Process the document and return the text of the selected pages.
 
@@ -830,7 +830,7 @@ if __name__ == "__main__":
             sys.exit(f"Page number(s) {wrong_pages} not in '{doc}'.")
 
     # get the markdown string
-    md_string = to_markdown(doc, pages=pages, enable_code_blocks=False)
+    md_string = to_markdown(doc, pages=pages, enable_code_blocks=True)
 
     # output to a text file with extension ".md"
     outname = doc.name.replace(".pdf", ".md")

--- a/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
+++ b/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
@@ -226,7 +226,7 @@ def to_markdown(
     page_height=None,
     table_strategy="lines_strict",
     graphics_limit=None,
-    enable_code_blocks=True,
+    enable_code_blocks=False,
 ) -> str:
     """Process the document and return the text of the selected pages.
 
@@ -830,7 +830,7 @@ if __name__ == "__main__":
             sys.exit(f"Page number(s) {wrong_pages} not in '{doc}'.")
 
     # get the markdown string
-    md_string = to_markdown(doc, pages=pages, enable_code_blocks=True)
+    md_string = to_markdown(doc, pages=pages, enable_code_blocks=False)
 
     # output to a text file with extension ".md"
     outname = doc.name.replace(".pdf", ".md")


### PR DESCRIPTION
# Add `enable_code_blocks` Option to Control Code Block Formatting in Markdown Output

## Summary
This PR introduces a new option `enable_code_blocks` to the `to_markdown` function in `pymupdf_rag.py`. This option allows users to enable or disable code block formatting in the generated Markdown output. This option is defaulted to `False` to maintain backward compatibility.

## Changes
1. **Code Changes**:
   - Added `enable_code_blocks` parameter to the `to_markdown` function.
   - Updated the `write_text` function to respect the `enable_code_blocks` setting.

## Motivation
Sometimes, the automatic conversion of text to code blocks in the Markdown output can lead to formatting issues. This new option provides users with the flexibility to control whether code blocks should be included in the output, improving the usability of the tool in various scenarios.

## Example
`md_output = pymupdf4llm.to_markdown(pdf_path, enable_code_blocks=True)`
