### PR TITLE
Fix `to_markdown` function to be either `str` or `list[dict]`

### DIFF
--- a/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
+++ b/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
@@ -256,7 +256,7 @@ def to_markdown(
     ignore_code=False,
     extract_words=False,
     show_progress=True,
-) -> str:
+) -> str | list[dict]:
     """Process the document and return the text of the selected pages.
 
     Args:


### PR DESCRIPTION
Fixes #194 