### PR TITLE
Faster image filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _build
 build
+*.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 _build
 build
 *.egg-info
+__pycache__
+.pytest_cache


### PR DESCRIPTION
Closes #204 

This adds a simple fix for my edge case, where I have pages with >6000 detected image rectangles. The algorithm which discards rectangles inside other rectangles churns on forever on such pages, because of the O(n*n) complexity.

Since most of these rectangles are tiny, a few pixels in size, a sufficient fix is to filter out tiny images. By default there is already a filter to not save images smaller than image_size_limit. I apply that limit before considering which rectangles to keep, the reasoning being: if a small image is not anyway inside a larger one, it would not be stored afterwards anyway, and if it is inside, there is also no harm done in removing it.

Since filtering by image size is O(n), this speeds up the code for my edge case.

This is a minimal change to solve the problem, please accept it. I made the extraction algorithm configurable, with the parameter "image_extract_algorithm" which uses the new algorithm by default. This is just defensive programming, so that people can keep the old behavior if that is for some reason required, although I cannot see any reason why the algorithm should give different results from the old one, apart from running faster. In my tests they produced the same results.