### PR TITLE
Adds a cache for comparing bboxes to speedup processing

### DIFF
--- a/pymupdf4llm/pymupdf4llm/helpers/multi_column.py
+++ b/pymupdf4llm/pymupdf4llm/helpers/multi_column.py
@@ -157,6 +157,9 @@ def column_boxes(
             if bb0 == bb1:
                 del nblocks[i]
 
+        if len(nblocks) == 0:
+            return nblocks
+
         # 2. repair sequence in special cases:
         # consecutive bboxes with almost same bottom value are sorted ascending
         # by x-coordinate.
@@ -452,6 +455,8 @@ def column_boxes(
 
     # do some elementary cleaning
     nblocks = clean_nblocks(nblocks)
+    if len(nblocks) == 0:
+        return nblocks
 
     # several phases of rectangle joining
     nblocks = join_rects_phase1(nblocks)


### PR DESCRIPTION
There are 2 places in `multi_column.py` where comparing bboxes can profit from using a cache.

This PR takes care of that. The locations are

-  the joining of bboxes to establish column structure
- `join_rects_phase3`

Original processing time of a problematic PDF: **~30 minutes**
Processing time after applying PR: **40s**

Solves issue https://github.com/pymupdf/RAG/issues/215