### PR TITLE
Fixed a bug with incorrect block sequence in columns

### DIFF
--- a/pymupdf4llm/pymupdf4llm/helpers/multi_column.py
+++ b/pymupdf4llm/pymupdf4llm/helpers/multi_column.py
@@ -248,6 +248,7 @@ def column_boxes(
                     )
                     if test == set((tuple(prect0), tuple(prect1))):
                         prect0 |= prect1
+                        prects[0] = prect0
                         del prects[i]
                         repeat = True
             new_rects.append(prect0)


### PR DESCRIPTION
It solves an issue #192 with wrong column extraction, while the lines in the column weren't joined properly. The test set in line 246 was created from the old value of prects[0], but compared with the new prect0.