### PR TITLE
Fix for ZeroDivisionError for cwidth in pymupdf_rag.py

### DIFF
--- a/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
+++ b/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
@@ -593,7 +593,7 @@ def to_markdown(
                             span0["text"]
                         )
                         if cwidth == 0.0:
-                            cwidth = 5.0
+                            cwidth = span0["size"] * 0.5
                         text = " " * int(round(dist / cwidth)) + text
                     out_string += text
             if not code:

--- a/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
+++ b/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
@@ -592,6 +592,8 @@ def to_markdown(
                         cwidth = (span0["bbox"][2] - span0["bbox"][0]) / len(
                             span0["text"]
                         )
+                        if cwidth == 0.0:
+                            cwidth = 5.0
                         text = " " * int(round(dist / cwidth)) + text
                     out_string += text
             if not code:


### PR DESCRIPTION
The calculation for `cwidth` in `write_text`:
```
cwidth = (span0["bbox"][2] - span0["bbox"][0]) / len(
    span0["text"]
)
```
 may result in a value of 0.0 leading to a `ZeroDivisionError` in line
```
text = " " * int(round(dist / cwidth)) + text
```
This happens when entry 0 and 2 of the `bbox` above have the same value - example from pdf below: `Rect(143.51992797851562, 220.53456115722656, 143.51992797851562, 230.90191650390625)`

Possible solutions:

1. When 0.0, simply do not prepend spaces (screenshot 2). This is not the best solution if you compare it to the original PDF (screenshot 1), where these lines are indented relative to first bullet.
2. When 0.0, use a sensible default, e.g. half the font size (screenshot 3). This is more in line with the original PDF in screenshot 1.

This PR implements the second solution.

![Image](https://github.com/user-attachments/assets/6b7d9201-0e59-4725-9e93-8f702cd62887)

![Image](https://github.com/user-attachments/assets/a3f14267-3ed2-4d8e-9ab7-a1fd1fd2c2da)

![Image](https://github.com/user-attachments/assets/b2d09e91-7128-496c-aa7d-66d6790bb3e7)