### PR TITLE
Fix UnboundLocalError for table_strategy in pymupdf_rag.py

### DIFF
--- a/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
+++ b/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
@@ -910,7 +910,7 @@ def to_markdown(
         return nwords
 
     def get_page_output(
-        doc, pno, margins, textflags, FILENAME, IGNORE_IMAGES, IGNORE_GRAPHICS
+        doc, pno, margins, textflags, FILENAME, IGNORE_IMAGES, IGNORE_GRAPHICS, table_strategy
     ):
         """Process one page.
 
@@ -1164,7 +1164,7 @@ def to_markdown(
         pages = ProgressBar(pages)
     for pno in pages:
         parms = get_page_output(
-            doc, pno, margins, textflags, FILENAME, IGNORE_IMAGES, IGNORE_GRAPHICS
+            doc, pno, margins, textflags, FILENAME, IGNORE_IMAGES, IGNORE_GRAPHICS, table_strategy
         )
         if page_chunks is False:
             document_output += parms.md_string


### PR DESCRIPTION
**Issue**:

It seems this was never an issue previously until the most recent update. The root cause is in the to_markdown function within pymupdf_rag.py, where the nested helper function `get_page_output` was getting a UnboundLocalError. I found that this was happening because the `table_strategy` variable was conditionally assigned a value (None) inside `get_page_output` if the `GRAPHICS_LIMIT` was exceeded:

_See error below.._

![Screenshot 2025-05-10 at 12 33 43 pm](https://github.com/user-attachments/assets/2f101760-4106-4617-8f3f-70afdf1ca44e)

If the `GRAPHICS_LIMIT` condition (specifically, `GRAPHICS_LIMIT` being a non-none value and `graphics_count` > `GRAPHICS_LIMIT` being false for a page) wasn't met, the local assignment `table_strategy = None` inside `get_page_output` would not execute. 

**Solution:**
I needed to use this package so did a quick fix on my end, the `table_strategy` variable is now explicitly passed as a parameter from the `to_markdown` function to the `get_page_output` function.
