### PR TITLE
Update pymupdf_rag.py

### DIFF
--- a/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
+++ b/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
@@ -1253,7 +1253,7 @@ if __name__ == "__main__":
     import time
 
     try:
-        filename = "sample_document.pdf"
+        filename = f"{sys.argv[1]}"
     except IndexError:
         print(f"Usage:\npython {os.path.basename(__file__)} input.pdf")
         sys.exit()


### PR DESCRIPTION
Running the command "python pymupdf_rag.py input.pdf" it was giving error of "sample_document.pdf" not found because in line 1256 filename variable was defined as "sample_document.pdf". So instead of taking file path from the command, it was directly considering "sample_document.pdf". But now I have added f"{sys.argv[1]}" . now it is reading path given in 1st argument in command.