### PR TITLE
Fix KeyError on missing ‘alpha’ span attribute in `get_raw_lines()`

### DIFF
--- a/pymupdf4llm/pymupdf4llm/helpers/get_text_lines.py
+++ b/pymupdf4llm/pymupdf4llm/helpers/get_text_lines.py
@@ -118,7 +118,7 @@ def get_raw_lines(
                 if is_white(s["text"]):  # ignore white text
                     continue
                 # Ignore invisible text. Type 3 font text is never invisible.
-                if s["font"] != "Unnamed-T3" and s["alpha"] == 0 and ignore_invisible:
+                if s["font"] != "Unnamed-T3" and s.get("alpha", 255) == 0 and ignore_invisible:
                     continue
                 if abs(sbbox & clip) < abs(sbbox) * 0.8:  # if not in clip
                     continue


### PR DESCRIPTION
When running `to_markdown()`, span dictionaries returned by `page.get_text("dict")` may omit the `"alpha"` key. The existing logic assumed its presence and crashed with `KeyError`. This patch:

* Uses `s.get("alpha", 255)` so that missing values default to fully opaque.
* Prevents the line‐clustering helper from ever accessing a nonexistent `alpha` key.

**Impact:**
Patch is localised to `get_raw_lines()` and does not affect any public API;
