### PR TITLE
Fix ValueError crash when processing pages with no body content

### DIFF
--- a/pymupdf4llm/pymupdf4llm/helpers/utils.py
+++ b/pymupdf4llm/pymupdf4llm/helpers/utils.py
@@ -404,6 +404,16 @@ def find_reading_order(page_rect, blocks, boxes, vertical_gap: float = 12) -> li
         else:
             body_boxes.append(box)
 
+    # Handle edge case: pages with no body content (only headers/footers or empty)
+    # This can occur with scanned images, blank pages, or pages with only headers/footers
+    if not body_boxes:
+        # Return only headers and footers sorted by position
+        final = (
+            sorted(page_headers, key=lambda r: (r[1], r[0]))
+            + sorted(page_footers, key=lambda r: (r[1], r[0]))
+        )
+        return final
+
     # compute joined boxes of body
     joined_boxes = pymupdf.Rect(
         min(b[0] for b in body_boxes),


### PR DESCRIPTION
## Summary

Fixes #320

This PR adds a null-check for empty `body_boxes` list in the `find_reading_order()` function to prevent `ValueError: min() iterable argument is empty` crash.

## Problem

The library crashes when processing PDF pages that have no body content (only headers/footers or empty):

```python
# Lines 409-412 in utils.py
joined_boxes = pymupdf.Rect(
    min(b[0] for b in body_boxes),  # ❌ Crashes when body_boxes is empty
    min(b[1] for b in body_boxes),
    max(b[2] for b in body_boxes),
    max(b[3] for b in body_boxes),
)
```

## Solution

Added an early-return check after the `body_boxes` list is populated:

```python
# Handle edge case: pages with no body content
if not body_boxes:
    # Return only headers and footers sorted by position
    final = (
        sorted(page_headers, key=lambda r: (r[1], r[0]))
        + sorted(page_footers, key=lambda r: (r[1], r[0]))
    )
    return final
```

## Testing

✅ **Before Fix**: Crashed with `ValueError` on pages with scanned images and failed OCR  
✅ **After Fix**: Successfully processes all pages, gracefully handling empty body content

Tested with:
- PDF pages containing only scanned images (OCR failures)
- Pages with "Image too small to scale" / "Line cannot be recognized" OCR errors
- Pages with 0 text blocks and no layout information

## Edge Cases Handled

This fix handles pages with:
- Scanned images where OCR fails to extract text
- Blank pages
- Pages with only header/footer content
- Pages with only graphics/drawings and no text blocks

## Impact

- **Breaking Changes**: None
- **Behavior Changes**: Pages with no body content now return headers/footers instead of crashing
- **Performance**: Minimal (single list length check)
- **Backwards Compatibility**: Full compatibility maintained

## Code Quality

- ✅ Minimal change (10 lines added)
- ✅ No modification to existing logic paths
- ✅ Clear comments explaining the edge case
- ✅ Follows existing code style and patterns

## Related

- Issue: #320
- Affected function: `find_reading_order()` in `pymupdf4llm/helpers/utils.py`
- Root cause: Missing null-check for empty list before min()/max() operations