### PR TITLE
Fix bug in helper function parse_document.

### DIFF
--- a/pymupdf4llm/pymupdf4llm/helpers/document_layout.py
+++ b/pymupdf4llm/pymupdf4llm/helpers/document_layout.py
@@ -847,7 +847,7 @@ def parse_document(
                 blocks=blocks,
             )
         else:
-            decision = {"should_ocr": False}
+            decision = {"should_ocr": False, 'has_ocr_text': False}
 
         if decision["has_ocr_text"]:  # prevent MD styling if already OCR'd
             page_full_ocred = True


### PR DESCRIPTION
In a very straightforward way, if the else statement on line 849 of the file document_layout.py is followed, line 852 throws the following error due to the lack of the key "has_ocr_text" on the decision dict:

```
File ~/miniconda3/envs/envname/lib/python3.13/site-packages/pymupdf4llm/helpers/document_layout.py:852, in parse_document(doc, filename, image_dpi, ocr_dpi, image_format, image_path, pages, show_progress, embed_images, write_images, force_text)
    849 else:
    850     decision = {"should_ocr": False}
--> 852 if decision["has_ocr_text"]:  # prevent MD styling if already OCR'd
    853     page_full_ocred = True
    855 if decision["should_ocr"]:
    856     # We should be OCR: check full-page vs. text-only

KeyError: 'has_ocr_text'
```