### PR TITLE
Fix ValueError when processing tables with empty cells

### DIFF
--- a/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
+++ b/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
@@ -1052,6 +1052,10 @@ def to_markdown(
         else:
             tabs = page.find_tables(clip=parms.clip, strategy=table_strategy)
             for t in tabs.tables:
+                # Skip tables with no valid cells (would cause bbox calculation to fail)
+                if not any(c is not None for c in t.cells):
+                    continue
+
                 # remove tables with too few rows or columns
                 if t.row_count < 2 or t.col_count < 2:
                     omitted_table_rects.append(pymupdf.Rect(t.bbox))


### PR DESCRIPTION
## Summary
This PR fixes a `ValueError: min() arg is an empty sequence` that occurred when processing PDFs with tables that have empty or invalid cell sequences.

## Problem
When `to_markdown()` processes a table with no valid cells, accessing the `t.bbox` property causes PyMuPDF's table module to call `min()` on an empty sequence, resulting in a crash.

Error trace:
```
File "pymupdf4llm/helpers/pymupdf_rag.py", line 1057, in get_page_output
    omitted_table_rects.append(pymupdf.Rect(t.bbox))
                                            ^^^^^^
File "pymupdf/table.py", line 1506, in bbox
    min(map(itemgetter(0), c)),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: min() arg is an empty sequence
```
