### PR TITLE
Version 0.2.7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## Changes in version 0.2.7
+
+### Fixes:
+
+* [323](https://github.com/pymupdf/pymupdf4llm/issues/323) - `page_chunks=True` parameter was ignored in PyMuPDF-Layout mode
+
+### Other Changes:
+
+* Methods `to_markdown()` / `to_text()` now both support Page chunk output via parameter `page_chunks=True`.
+
+------
+
 ## Changes in version 0.2.6
 
 ### Fixes:

--- a/pdf4llm/setup.py
+++ b/pdf4llm/setup.py
@@ -6,7 +6,7 @@ setup_py_cwd = os.path.dirname(__file__)
 with open(os.path.join(setup_py_cwd, "README.md"), encoding="utf-8") as f:
     readme = f.read()
 
-version = "0.2.6"  # must always equal the pymupdf4llm version
+version = "0.2.7"  # must always equal the pymupdf4llm version
 
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/pymupdf4llm/pymupdf4llm/__init__.py
+++ b/pymupdf4llm/pymupdf4llm/__init__.py
@@ -147,6 +147,7 @@ else:
         ocr_dpi=400,
         use_ocr=True,
         table_format="grid",
+        page_chunks=False,
         # unsupported options for pymupdf layout:
         **kwargs,
     ):
@@ -166,6 +167,7 @@ else:
             ignore_code=ignore_code,
             show_progress=show_progress,
             table_format=table_format,
+            page_chunks=page_chunks,
         )
 
 

--- a/pymupdf4llm/pymupdf4llm/helpers/get_text_lines.py
+++ b/pymupdf4llm/pymupdf4llm/helpers/get_text_lines.py
@@ -15,13 +15,9 @@ License GNU Affero GPL 3.0
 import sys
 
 import pymupdf
-from pymupdf4llm.helpers.utils import WHITE_CHARS
+from pymupdf4llm.helpers.utils import is_white
 
 TYPE3_FONT_NAME = "Unnamed-T3"
-
-
-def is_white(text):
-    return WHITE_CHARS.issuperset(text)
 
 
 def get_raw_lines(

--- a/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
+++ b/pymupdf4llm/pymupdf4llm/helpers/pymupdf_rag.py
@@ -43,9 +43,14 @@ from dataclasses import dataclass
 
 import pymupdf
 from pymupdf import mupdf
-from pymupdf4llm.helpers.get_text_lines import get_raw_lines, is_white
+from pymupdf4llm.helpers.get_text_lines import get_raw_lines
 from pymupdf4llm.helpers.multi_column import column_boxes
-from pymupdf4llm.helpers.utils import BULLETS, REPLACEMENT_CHARACTER, startswith_bullet
+from pymupdf4llm.helpers.utils import (
+    BULLETS,
+    REPLACEMENT_CHARACTER,
+    startswith_bullet,
+    is_white,
+)
 
 try:
     from tqdm import tqdm as ProgressBar

--- a/pymupdf4llm/pymupdf4llm/versions_file.py
+++ b/pymupdf4llm/pymupdf4llm/versions_file.py
@@ -1,3 +1,3 @@
 # Generated file - do not edit.
 MINIMUM_PYMUPDF_VERSION = (1, 26, 6)
-VERSION = '0.2.6'
+VERSION = '0.2.7'

--- a/pymupdf4llm/setup.py
+++ b/pymupdf4llm/setup.py
@@ -11,7 +11,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 
-version = "0.2.6"
+version = "0.2.7"
 pymupdf_version = "1.26.6"
 pymupdf_version_tuple = tuple(int(x) for x in pymupdf_version.split("."))
 requires = [f"pymupdf>={pymupdf_version}", "tabulate"]


### PR DESCRIPTION
Activate "page chunks" again in PyMuPDF-Layout mode. This applies to method `to_markdown` as well as the new PyMuPDF-Layout-specific method `to_text`. The per-page dictionaries generated if `page_chunks=True` now contain layout bbox information of for the page.